### PR TITLE
Enhance URL handling in NetworkInterceptor For Better Request

### DIFF
--- a/src/interceptors/NetworkInterceptor.ts
+++ b/src/interceptors/NetworkInterceptor.ts
@@ -200,7 +200,18 @@ export class NetworkInterceptor {
   ): typeof global.fetch {
     return async (input: RequestInfo | URL, init?: RequestInit) => {
       const startTime = performance.now();
-      const url = typeof input === 'string' ? input : input.toString();
+      const url =
+        typeof input === 'string'
+          ? input
+          : typeof input === 'object' && input !== null
+          ? // Prefer Request/URL fields when available; fall back to string conversion.
+            (input as Request).url ||
+            (input as URL).href ||
+            (typeof (input as { toString?: () => string }).toString ===
+            'function'
+              ? (input as { toString: () => string }).toString()
+              : String(input))
+          : String(input);
       const method = (init?.method || 'GET').toUpperCase();
 
       try {


### PR DESCRIPTION
### Summary

Make URL extraction in `NetworkInterceptor` more reliable across different types of fetch inputs.

Related Issue: [Network tab shows GET [object Object] when fetch is called with Request/URL object](https://github.com/lokal-app/react-native-bugbubble/issues/2)